### PR TITLE
Fix: Downscale claim staying in pending

### DIFF
--- a/artifacts/deployment.yml
+++ b/artifacts/deployment.yml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: kotary
       containers:
         - name: kotary
-          image: cagip/kotary:v0.24.0
+          image: cagip/kotary:v1.24.0
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/internal/controller/claim.go
+++ b/internal/controller/claim.go
@@ -109,6 +109,7 @@ func (c *Controller) syncHandlerClaim(key string) error {
 	}
 
 	utils.ClaimCounter.WithLabelValues("success").Inc()
+	klog.Infof("< RequestQuotaClaim '%s' ACCEPTED >", claim.Name)
 
 	// Everything went well
 	return nil
@@ -146,6 +147,7 @@ func (c *Controller) updateResourceQuotaClaimStatus(claim *cagipv1.ResourceQuota
 
 // Update claim phase to Rejected with a msg
 func (c *Controller) claimRejected(claim *cagipv1.ResourceQuotaClaim, msg string) (err error) {
+	klog.Infof("< RequestQuotaClaim '%s' set to REJECTED >", claim.Name)
 	// Notify via an event
 	c.recorder.Event(claim, v1Core.EventTypeWarning, cagipv1.PhaseRejected, msg)
 	// Update ResourceQuotaClaim Status to Rejected Phase
@@ -156,6 +158,7 @@ func (c *Controller) claimRejected(claim *cagipv1.ResourceQuotaClaim, msg string
 
 // Update claim phase to Pending with a msg
 func (c *Controller) claimPending(claim *cagipv1.ResourceQuotaClaim, msg string) (err error) {
+	klog.Infof("< RequestQuotaClaim '%s' set to PENDING >", claim.Name)
 	// Notify via an event
 	c.recorder.Event(claim, v1Core.EventTypeWarning, cagipv1.PhasePending, msg)
 	// Update ResourceQuotaClaim Status to Rejected Phase

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -394,15 +394,15 @@ func (c *Controller) handlePod(obj interface{}) {
 		klog.Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 	}
 	//retrieve the namespace of the pod
-	Pod_Namespace := object.GetNamespace()
+	podNamespace := object.GetNamespace()
 
-	klog.Infof("Processing pod: %s (%s)", object.GetName(), Pod_Namespace)
+	klog.Infof("Processing pod: %s (%s)", object.GetName(), podNamespace)
 
 	// Empty selector
 	selector, _ := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{})
 
 	//retrieve the list of current quotaclaims in the namespace
-	QuotaClaims, err := c.resourceQuotaClaimLister.ResourceQuotaClaims(Pod_Namespace).List(selector)
+	quotaClaims, err := c.resourceQuotaClaimLister.ResourceQuotaClaims(podNamespace).List(selector)
 
 	if err != nil {
 		klog.Infof("error while getting quotaclaims: %s", err)
@@ -410,7 +410,7 @@ func (c *Controller) handlePod(obj interface{}) {
 	}
 
 	//iterate through the list and enqueue claims to be treated
-	for _, claim := range QuotaClaims {
+	for _, claim := range quotaClaims {
 		notReject := claim.Status.Phase != cagipv1.PhaseRejected
 		notAccepted := claim.Status.Phase != cagipv1.PhaseAccepted
 		if notReject && notAccepted {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -122,6 +122,7 @@ func NewController(
 	resourceQuotaClaimInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: controller.enqueueResourceQuotaClaim,
 		UpdateFunc: func(old, new interface{}) {
+			klog.Infof("============= RequestQuotaClaim informer is invoqued =============")
 			newQuotaClaim := new.(*cagipv1.ResourceQuotaClaim)
 			oldQuotaClaim := old.(*cagipv1.ResourceQuotaClaim)
 			if newQuotaClaim.ResourceVersion == oldQuotaClaim.ResourceVersion {
@@ -134,7 +135,16 @@ func NewController(
 	namespaceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: controller.enqueueNamespace,
 		UpdateFunc: func(old, new interface{}) {
+			klog.Infof("============= Namespace Informer is invoqued =============")
 			controller.enqueueNamespace(new)
+		},
+	})
+
+	//Set up an event handler for pod deletions to handle changes in Resource Used
+	podsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: func(obj interface{}) {
+			klog.Infof("============= Pods informer is invoqued (delete) =============")
+			controller.handlePod(obj)
 		},
 	})
 
@@ -228,6 +238,7 @@ func (c *Controller) processNextWorkClaim() bool {
 		defer c.resourceQuotaClaimWorkQueue.Done(obj)
 		var key string
 		var ok bool
+		klog.Infof("Working on %s quotaclaim", key)
 		// We expect strings to come off the resourceQuotaClaimWorkQueue. These are of the
 		// form namespace/name. We do this as the delayed nature of the
 		// resourceQuotaClaimWorkQueue means the items in the informer cache may actually be
@@ -340,23 +351,70 @@ func (c *Controller) handleObject(obj interface{}) {
 			utilruntime.HandleError(fmt.Errorf("error decoding object tombstone, invalid type"))
 			return
 		}
-		klog.V(4).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
+		klog.Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 	}
-	klog.V(4).Infof("Processing object: %s", object.GetName())
+	klog.Infof("Processing object: %s", object.GetName())
 	if ownerRef := metav1.GetControllerOf(object); ownerRef != nil {
 		// If this object is not owned by a ResourceQuotaClaims, we should not do anything more
 		// with it.
 		if ownerRef.Kind != "ResourceQuotaClaims" {
+			klog.Infof("not owned by a ResourceQuotaClaims")
 			return
 		}
 
 		claim, err := c.resourceQuotaClaimLister.ResourceQuotaClaims(object.GetNamespace()).Get(ownerRef.Name)
 		if err != nil {
-			klog.V(4).Infof("ignoring orphaned object '%s' of ResourceQuotaClaims '%s'", object.GetSelfLink(), ownerRef.Name)
+			klog.Infof("ignoring orphaned object '%s' of ResourceQuotaClaims '%s'", object.GetSelfLink(), ownerRef.Name)
 			return
 		}
-
+		klog.Infof("Processing claim: %s", claim)
 		c.enqueueResourceQuotaClaim(claim)
 		return
+	}
+}
+
+// handlePod will take a pod interface in argument and try to find all its Claims that are still not
+// treated and enqueue them to be processed.
+func (c *Controller) handlePod(obj interface{}) {
+
+	//get the pod object
+	var object metav1.Object
+	var ok bool
+	if object, ok = obj.(metav1.Object); !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("error decoding object, invalid type"))
+			return
+		}
+		object, ok = tombstone.Obj.(metav1.Object)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("error decoding object tombstone, invalid type"))
+			return
+		}
+		klog.Infof("Recovered deleted object '%s' from tombstone", object.GetName())
+	}
+	//retrieve the namespace of the pod
+	Pod_Namespace := object.GetNamespace()
+
+	klog.Infof("Processing pod: %s (%s)", object.GetName(), Pod_Namespace)
+
+	// Empty selector
+	selector, _ := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{})
+
+	//retrieve the list of current quotaclaims in the namespace
+	QuotaClaims, err := c.resourceQuotaClaimLister.ResourceQuotaClaims(Pod_Namespace).List(selector)
+
+	if err != nil {
+		klog.Infof("error while getting quotaclaims: %s", err)
+		return
+	}
+
+	//iterate through the list and enqueue claims to be treated
+	for _, claim := range QuotaClaims {
+		notReject := claim.Status.Phase != cagipv1.PhaseRejected
+		notAccepted := claim.Status.Phase != cagipv1.PhaseAccepted
+		if notReject && notAccepted {
+			c.enqueueResourceQuotaClaim(claim)
+		}
 	}
 }


### PR DESCRIPTION
Fix bug concerning Downscale Quotaclaim that were staying infinitly in PENDING status.

The bug was that nothing was re running the claims that had been set to pending. PENDING claims were staying in pending even after someone deleted a pod. The claims were just never re evaluated.

Fixed it by adding an Informer that looks at pods in namespace. Requeue all claims that are pending to be re-evaluated  on every pod update inside the namespace.